### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.3] - 2026-07-02
+
+### Fixed
+- Tightened the `ecto_sql` requirement from `~> 3.0` to `~> 3.13`. `Blink.Seeder.run/3` calls `Ecto.Repo.transact/2`, which was added in Ecto 3.13.0. Under the previous constraint the dependency resolved happily against Ecto 3.12, then raised `UndefinedFunctionError` at seed time; the requirement now fails at dependency resolution instead.
+
 ## [0.6.2] - 2026-07-01
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Blink.MixProject do
   use Mix.Project
 
-  @version "0.6.2"
+  @version "0.6.3"
 
   def project do
     [
@@ -45,7 +45,7 @@ defmodule Blink.MixProject do
 
   defp deps do
     [
-      {:ecto_sql, "~> 3.0"},
+      {:ecto_sql, "~> 3.13"},
       {:nimble_csv, "~> 1.2"},
       {:jason, "~> 1.4"},
       {:postgrex, "~> 0.17", only: :test},


### PR DESCRIPTION
## Summary

Tightens the `ecto_sql` requirement from `~> 3.0` to `~> 3.13`.

`Blink.Seeder.run/3` calls `Ecto.Repo.transact/2`, which was added in **Ecto 3.13.0**. Because `run/3` dispatches `transact` on a `repo` module bound at runtime, the compiler can't see the missing function — so under the old `~> 3.0` constraint the dependency resolved happily against Ecto 3.12 and then raised `UndefinedFunctionError` at seed time. The tightened requirement moves the failure to dependency resolution, where it belongs.

Reported by a downstream consumer (scrum-poker) that hit the runtime crash on Ecto 3.12.

## Changes

- `mix.exs` — `{:ecto_sql, "~> 3.0"}` → `{:ecto_sql, "~> 3.13"}`; version `0.6.2` → `0.6.3`
- `CHANGELOG.md` — new `0.6.3` entry

## Notes

This drops support for consumers pinned below Ecto 3.13. The backward-compatible alternative would be to swap `repo.transact/2` back to `repo.transaction/2` in the seeder; tightening the constraint was chosen as the fail-fast option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)